### PR TITLE
Allow build labels like wildcards on the command line

### DIFF
--- a/work/BUILD
+++ b/work/BUILD
@@ -6,5 +6,8 @@ go_library(
         "//generate",
         "//watch",
     ],
-    deps = ["//config"],
+    deps = [
+        "///third_party/go/github.com_bazelbuild_buildtools//labels",
+        "//config",
+    ],
 )

--- a/work/work.go
+++ b/work/work.go
@@ -2,18 +2,29 @@ package work
 
 import (
 	"errors"
+	"github.com/bazelbuild/buildtools/labels"
 	"github.com/please-build/puku/config"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func ExpandPaths(origWD string, paths []string) ([]string, error) {
 	ret := make([]string, 0, len(paths))
 	for _, path := range paths {
-		// Join the path with the original working directory. We would have cd'ed to the root of the plz repo by this
-		// point
-		path = filepath.Join(origWD, path)
+		// Handle using build label style syntax a bit like `plz build`
+		if strings.HasPrefix(path, "//") {
+			l := labels.Parse(path)
+			path = l.Package
+		} else {
+			if strings.HasPrefix(path, ":") {
+				path = "."
+			}
+			// Join the path with the original working directory. We would have cd'ed to the root of the plz repo by this
+			// point
+			path = filepath.Join(origWD, path)
+		}
 
 		if filepath.Base(path) != "..." {
 			ret = append(ret, path)


### PR DESCRIPTION
Then the syntax for specifying paths is the same as `plz build` etc. which will make it integrate really well as a plz alias. 

A follow on from this would be to limit it to only update the actual target specified.