### PR TITLE
Use target package name when searching for local dep

### DIFF
--- a/generate/deps.go
+++ b/generate/deps.go
@@ -132,7 +132,18 @@ func (u *Update) localDep(conf *config.Config, importPath string) (string, error
 			continue
 		}
 
-		if kind.Type == kinds.Lib {
+		if kind.Type != kinds.Lib {
+			continue
+		}
+
+		name := rule.Name()
+		pkg := rule.Attr("package")
+		if pkg != nil {
+			if str, ok := pkg.(*build.StringExpr); ok {
+				name = str.Value
+			}
+		}
+		if strings.HasSuffix(path, name) {
 			libTargets = append(libTargets, rule)
 		}
 	}

--- a/generate/deps_test.go
+++ b/generate/deps_test.go
@@ -42,11 +42,11 @@ func TestLocalDeps(t *testing.T) {
 
 	trgt, err := u.localDep(new(config.Config), "test_project/foo")
 	require.NoError(t, err)
-	assert.Equal(t, "//test_project/foo:bar", trgt)
+	assert.Equal(t, "//test_project/foo", trgt)
 
 	trgt, err = u.localDep(new(config.Config), "github.com/some/module/test_project/foo")
 	require.NoError(t, err)
-	assert.Equal(t, "//test_project/foo:bar", trgt)
+	assert.Equal(t, "//test_project/foo", trgt)
 }
 
 func TestBuildTarget(t *testing.T) {

--- a/test_project/BUILD_FILE
+++ b/test_project/BUILD_FILE
@@ -1,1 +1,1 @@
-go_library(name = "foo")
+go_library(name = "bar")

--- a/test_project/foo/BUILD_FILE.plz
+++ b/test_project/foo/BUILD_FILE.plz
@@ -1,1 +1,1 @@
-go_library(name = "bar")
+go_library(name = "foo")


### PR DESCRIPTION
When searching for local dependency, only take target where package name or name match the requested importPath.

I had to update the test to have `//foo:foo` instead of `//foo:bar`.

Fixes #63

