### PR TITLE
Fix issue with NPE when trying to look up target sources

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -397,7 +397,7 @@ func (u *Update) updateRuleDeps(conf *config.Config, rule *rule, rules []*rule, 
 	done := map[string]struct{}{}
 
 	// If the rule operates on non-go source files (e.g. *.proto for proto_library) then we should skip updating
-	// its as we can't determine its deps from sources this way.
+	// it as we can't determine its deps from sources this way.
 	if rule.kind.NonGoSources {
 		return nil
 	}


### PR DESCRIPTION
We have the sources we find in the package directory, and in #55 we introduced the concept of having another mapping for the sources for a given target. This second map includes generated sources. We accidentally passed the wrong set downstream which can result in nil pointers.