### PR TITLE
Include generated files

### DIFF
--- a/generate/import.go
+++ b/generate/import.go
@@ -1,7 +1,6 @@
 package generate
 
 import (
-	"go/ast"
 	"go/parser"
 	"go/token"
 	"os"
@@ -40,10 +39,7 @@ func ImportDir(dir string) (map[string]*GoFile, error) {
 		if err != nil {
 			return nil, err
 		}
-
-		if f != nil {
-			ret[info.Name()] = f
-		}
+		ret[info.Name()] = f
 	}
 
 	return ret, nil
@@ -53,9 +49,6 @@ func importFile(dir, src string) (*GoFile, error) {
 	f, err := parser.ParseFile(token.NewFileSet(), filepath.Join(dir, src), nil, parser.ImportsOnly|parser.ParseComments)
 	if err != nil {
 		return nil, err
-	}
-	if IsGenerated(f) {
-		return nil, nil
 	}
 	imports := make([]string, 0, len(f.Imports))
 	for _, i := range f.Imports {
@@ -92,33 +85,4 @@ func (f *GoFile) kindType() kinds.Type {
 		return kinds.Bin
 	}
 	return kinds.Lib
-}
-
-// IsGenerated returns whether a file is generated this is copied from
-// https://go-review.googlesource.com/c/go/+/487935/8/src/go/ast/ast.go
-func IsGenerated(file *ast.File) bool {
-	_, ok := generator(file)
-	return ok
-}
-
-func generator(file *ast.File) (string, bool) {
-	for _, group := range file.Comments {
-		for _, comment := range group.List {
-			if comment.Pos() > file.Package {
-				break // after package declaration
-			}
-			// opt: check Contains first to avoid unnecessary array allocation in Split.
-			const prefix = "// Code generated "
-			if strings.Contains(comment.Text, prefix) {
-				for _, line := range strings.Split(comment.Text, "\n") {
-					if rest, ok := strings.CutPrefix(line, prefix); ok {
-						if gen, ok := strings.CutSuffix(rest, " DO NOT EDIT."); ok {
-							return gen, true
-						}
-					}
-				}
-			}
-		}
-	}
-	return "", false
 }

--- a/generate/import_test.go
+++ b/generate/import_test.go
@@ -18,7 +18,6 @@ func TestImportDir(t *testing.T) {
 	require.NotNil(t, foo)
 	require.NotNil(t, fooTest)
 	require.NotNil(t, externalTest)
-	assert.Nil(t, fooDir["generated.go"]) // Generated srcs are ignored
 
 	assert.Equal(t, foo.Imports, []string{"github.com/example/module"})
 	assert.Equal(t, fooTest.Imports, []string{"github.com/stretchr/testify/assert"})


### PR DESCRIPTION
It's common practice to check in generated files, so we're going to have to solve this a different way. We currently ignore symlinks so for the default behavior of `plz generate`, which is to link using symlinks, puku will correctly ignore these files.  