### PR TITLE
Only format paths that were originally passed in

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -85,7 +85,7 @@ func (u *Update) Update(paths ...string) error {
 	if err := u.update(conf); err != nil {
 		return err
 	}
-	return u.graph.FormatFiles(u.write, os.Stdout)
+	return u.graph.FormatFiles(u.write, os.Stdout, paths)
 }
 
 func (u *Update) Sync() error {
@@ -98,7 +98,7 @@ func (u *Update) Sync() error {
 		return fmt.Errorf("failed to read third party rules: %v", err)
 	}
 
-	return u.graph.FormatFiles(u.write, os.Stdout)
+	return u.graph.FormatFiles(u.write, os.Stdout, []string{})
 }
 
 func (u *Update) syncModFile(conf *config.Config, file *build.File, exitingRules map[string]*build.Rule) error {

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -67,7 +67,7 @@ go_library(
 	})
 
 	bs := new(bytes.Buffer)
-	err = g.FormatFiles(false, bs)
+	err = g.FormatFiles(false, bs, []string{})
 	require.NoError(t, err)
 
 	fooT := edit.FindTargetByName(g.files["foo"], "foo")

--- a/licences/licences.go
+++ b/licences/licences.go
@@ -117,7 +117,7 @@ func (l *Licenses) Update(paths []string, write bool) error {
 		}
 	}
 
-	return l.graph.FormatFiles(write, os.Stdout)
+	return l.graph.FormatFiles(write, os.Stdout, []string{})
 }
 
 func (l *Licenses) Get(mod, ver string) ([]string, error) {

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -139,7 +139,7 @@ func (m *Migrate) Migrate(write bool, modules []string, paths ...string) error {
 	if err := m.genRules(modules); err != nil {
 		return err
 	}
-	return m.graph.FormatFiles(write, os.Stdout)
+	return m.graph.FormatFiles(write, os.Stdout, paths)
 }
 
 func (m *Migrate) genRules(modules []string) error {


### PR DESCRIPTION
Before:
```
$ puku fmt vault/xpl/transactions/streaming/orchestrator/...
$ git diff --name-only
common/go/grpc/BUILD
vault/xpl/transactions/streaming/orchestrator/executors/BUILD
```
After:
```
$ puku fmt vault/xpl/transactions/streaming/orchestrator/...
$ git diff --name-only
vault/xpl/transactions/streaming/orchestrator/executors/BUILD
```