### PR TITLE
Downgrade visibility error to a warning

### DIFF
--- a/graph/BUILD
+++ b/graph/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//config",
         "//edit",
         "//fs",
+        "//logging",
     ],
 )
 

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -14,7 +14,10 @@ import (
 	"github.com/please-build/puku/config"
 	"github.com/please-build/puku/edit"
 	"github.com/please-build/puku/fs"
+	"github.com/please-build/puku/logging"
 )
+
+var log = logging.GetLogger()
 
 type Dependency struct {
 	From, To labels.Label
@@ -117,7 +120,7 @@ func (g *Graph) ensureVisibilities() error {
 			return err
 		}
 		if err := g.ensureVisibility(conf, dep); err != nil {
-			return fmt.Errorf("failed to set visibility: %v", err)
+			log.Warningf("failed to set visibility: %v", err)
 		}
 	}
 	return nil

--- a/logging/BUILD
+++ b/logging/BUILD
@@ -5,6 +5,7 @@ go_library(
         "//:all",
         "//cmd/puku:all",
         "//generate:all",
+        "//graph:all",
         "//watch:all",
     ],
     deps = [


### PR DESCRIPTION
There are some dodgy rule in our codebase that don't have a `name` arg. This confuses puku because it can't find the rule expression for that target. This logs a warning but still does the potentially useful bit of updating/generating the libs we're formatting. 