### PR TITLE
Use config of dependency folder during local dependency discovery

### DIFF
--- a/generate/deps.go
+++ b/generate/deps.go
@@ -48,7 +48,7 @@ func (u *Update) reallyResolveImport(conf *config.Config, i string) (string, err
 
 	// Check to see if the target exists in the current repo
 	if fs.IsSubdir(u.plzConf.ImportPath(), i) || u.plzConf.ImportPath() == "" {
-		t, err := u.localDep(conf, i)
+		t, err := u.localDep(i)
 		if err != nil {
 			return "", err
 		}
@@ -113,7 +113,7 @@ func (u *Update) isInScope(path string) bool {
 
 // localDep finds a dependency local to this repository, checking the BUILD file for a go_library target. Returns an
 // empty string when no target is found.
-func (u *Update) localDep(conf *config.Config, importPath string) (string, error) {
+func (u *Update) localDep(importPath string) (string, error) {
 	path := strings.Trim(strings.TrimPrefix(importPath, u.plzConf.ImportPath()), "/")
 	// If we're using GOPATH based resolution, we don't have a prefix to base whether a path is package local or not. In
 	// this case, we need to check if the directory exists. If it doesn't it's not a local import.
@@ -123,6 +123,11 @@ func (u *Update) localDep(conf *config.Config, importPath string) (string, error
 	file, err := u.graph.LoadFile(path)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse BUILD files in %v: %v", path, err)
+	}
+
+	conf, err := config.ReadConfig(path)
+	if err != nil {
+		return "", err
 	}
 
 	var libTargets []*build.Rule

--- a/generate/deps_test.go
+++ b/generate/deps_test.go
@@ -40,11 +40,11 @@ func TestLocalDeps(t *testing.T) {
 
 	u := NewUpdate(false, conf)
 
-	trgt, err := u.localDep(new(config.Config), "test_project/foo")
+	trgt, err := u.localDep("test_project/foo")
 	require.NoError(t, err)
 	assert.Equal(t, "//test_project/foo:bar", trgt)
 
-	trgt, err = u.localDep(new(config.Config), "github.com/some/module/test_project/foo")
+	trgt, err = u.localDep("github.com/some/module/test_project/foo")
 	require.NoError(t, err)
 	assert.Equal(t, "//test_project/foo:bar", trgt)
 }


### PR DESCRIPTION
Use configuration of the local dependency not the configuration of the source target.

Before this PR, when using a global `puku.json` that contains a `excludeBuiltinKinds`, this excluded kind is used during the dependency discovery leading to not take into account the `puku.json` file of the dependency folder.

For example, I have `/puku.json` with `"excludeBuiltinKinds": {"proto_library"}` and a `/foo/puku.json` that revert it with `  "libKinds": { "proto_library": { "nonGoSources": true } }`. If a `/bar` module depend on the `proto_libray()` of `foo`, then puku print `WARNING couldn't resolve...` and did not add the dependency in `/bar`.
