### PR TITLE
Do `go get` as part of module migration

### DIFF
--- a/cmd/puku/puku.go
+++ b/cmd/puku/puku.go
@@ -45,7 +45,7 @@ var opts = struct {
 	Migrate struct {
 		Write          bool     `short:"w" long:"write" description:"Whether to write the files back or just print them to stdout"`
 		ThirdPartyDirs []string `long:"third_party_dir" description:"Directories to find go_module rules to migrate"`
-		UpdateGoMod    bool     `short:"g" long:"update_go_mod" description:"Update the go mod with the module that is being migrated"`
+		UpdateGoMod    bool     `short:"g" long:"update_go_mod" description:"Update the go mod with the module(s) being migrated"`
 		Args           struct {
 			Modules []string `positional-arg-name:"modules" description:"The modules to migrate to go_repo"`
 		} `positional-args:"true"`

--- a/cmd/puku/puku.go
+++ b/cmd/puku/puku.go
@@ -45,7 +45,7 @@ var opts = struct {
 	Migrate struct {
 		Write          bool     `short:"w" long:"write" description:"Whether to write the files back or just print them to stdout"`
 		ThirdPartyDirs []string `long:"third_party_dir" description:"Directories to find go_module rules to migrate"`
-		UpdateGoMod    bool     `short:"g" long:"update-go-mod" description:"Update the go mod with the module that is being migrated"`
+		UpdateGoMod    bool     `short:"g" long:"update_go_mod" description:"Update the go mod with the module that is being migrated"`
 		Args           struct {
 			Modules []string `positional-arg-name:"modules" description:"The modules to migrate to go_repo"`
 		} `positional-args:"true"`

--- a/cmd/puku/puku.go
+++ b/cmd/puku/puku.go
@@ -45,6 +45,7 @@ var opts = struct {
 	Migrate struct {
 		Write          bool     `short:"w" long:"write" description:"Whether to write the files back or just print them to stdout"`
 		ThirdPartyDirs []string `long:"third_party_dir" description:"Directories to find go_module rules to migrate"`
+		UpdateGoMod    bool     `short:"g" long:"update-go-mod" description:"Update the go mod with the module that is being migrated"`
 		Args           struct {
 			Modules []string `positional-arg-name:"modules" description:"The modules to migrate to go_repo"`
 		} `positional-args:"true"`
@@ -106,7 +107,7 @@ var funcs = map[string]func(conf *config.Config, plzConf *please.Config, orignal
 			paths = []string{conf.GetThirdPartyDir()}
 		}
 		paths = work.MustExpandPaths(orignalWD, paths)
-		if err := migrate.New(conf, plzConf).Migrate(opts.Migrate.Write, opts.Migrate.Args.Modules, paths...); err != nil {
+		if err := migrate.New(conf, plzConf).Migrate(opts.Migrate.Write, opts.Migrate.UpdateGoMod, opts.Migrate.Args.Modules, paths...); err != nil {
 			log.Fatalf("%v", err)
 		}
 		return 0

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -139,13 +139,13 @@ func (m *Migrate) Migrate(write bool, updateGoMod bool, modules []string, paths 
 	}
 
 	// Now we can generate all the rules we need
-	if err := m.replaceRulesForModules(write, updateGoMod, modules); err != nil {
+	if err := m.replaceRulesForModules(updateGoMod, modules); err != nil {
 		return err
 	}
 	return m.graph.FormatFiles(write, os.Stdout)
 }
 
-func (m *Migrate) replaceRulesForModules(write, updateGoMod bool, modules []string) error {
+func (m *Migrate) replaceRulesForModules(updateGoMod bool, modules []string) error {
 	// If we're not migrating specific modules, do all of them
 	if len(modules) == 0 {
 		for _, parts := range m.moduleRules {

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -3,6 +3,7 @@ package migrate
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -22,6 +23,7 @@ import (
 func New(conf *config.Config, plzConf *please.Config) *Migrate {
 	g := graph.New(plzConf.BuildFileNames())
 	return &Migrate{
+		plzConf:           plzConf,
 		graph:             g,
 		thirdPartyFolder:  conf.GetThirdPartyDir(),
 		moduleRules:       map[string]*moduleParts{},
@@ -32,6 +34,7 @@ func New(conf *config.Config, plzConf *please.Config) *Migrate {
 
 // Migrate replaces go_module rules with the equivalent go_repo rules, generating filegroup replacePartsWithAliases where appropriate
 type Migrate struct {
+	plzConf           *please.Config
 	graph             *graph.Graph
 	thirdPartyFolder  string
 	moduleRules       map[string]*moduleParts
@@ -120,7 +123,7 @@ func binaryAlias(module, thirdPartyDir string, part *pkgRule) (*build.Rule, erro
 	return rule, nil
 }
 
-func (m *Migrate) Migrate(write bool, modules []string, paths ...string) error {
+func (m *Migrate) Migrate(write bool, updateGoMod bool, modules []string, paths ...string) error {
 	// Read all the BUILD files under the provided paths to find go_module and go_mod_download rules
 	for _, path := range paths {
 		f, err := m.graph.LoadFile(path)
@@ -136,27 +139,27 @@ func (m *Migrate) Migrate(write bool, modules []string, paths ...string) error {
 	}
 
 	// Now we can generate all the rules we need
-	if err := m.replaceRulesForModules(modules); err != nil {
+	if err := m.replaceRulesForModules(write, updateGoMod, modules); err != nil {
 		return err
 	}
 	return m.graph.FormatFiles(write, os.Stdout)
 }
 
-func (m *Migrate) replaceRulesForModules(modules []string) error {
+func (m *Migrate) replaceRulesForModules(write, updateGoMod bool, modules []string) error {
 	// If we're not migrating specific modules, do all of them
 	if len(modules) == 0 {
 		for _, parts := range m.moduleRules {
-			if err := m.replaceRules(parts); err != nil {
+			if err := m.replaceRules(updateGoMod, parts); err != nil {
 				return err
 			}
 		}
 	}
 
 	// Otherwise migrate the targeted modules, and their dependencies
-	return m.migrateTransitively(modules)
+	return m.migrateTransitively(updateGoMod, modules)
 }
 
-func (m *Migrate) migrateTransitively(mods []string) error {
+func (m *Migrate) migrateTransitively(updateGoMod bool, mods []string) error {
 	if len(mods) == 0 {
 		return nil
 	}
@@ -166,7 +169,7 @@ func (m *Migrate) migrateTransitively(mods []string) error {
 		return fmt.Errorf("couldn't find go_module rules for %v", mods[0])
 	}
 
-	if err := m.replaceRules(parts); err != nil {
+	if err := m.replaceRules(updateGoMod, parts); err != nil {
 		return err
 	}
 
@@ -175,7 +178,7 @@ func (m *Migrate) migrateTransitively(mods []string) error {
 	if err != nil {
 		return err
 	}
-	return m.migrateTransitively(append(mods[1:], deps...))
+	return m.migrateTransitively(updateGoMod, append(mods[1:], deps...))
 }
 
 func ruleIdx(file *build.File, rule *build.Rule) int {
@@ -229,12 +232,41 @@ func (m *Migrate) addNewRepoRule(name, version, download string, patches, licenc
 	return nil
 }
 
-func (m *Migrate) replaceRules(p *moduleParts) error {
+func (m *Migrate) addModuleToGoMod(module string) error {
+	if m.plzConf == nil {
+		return fmt.Errorf("No plzconfig found.")
+	}
+
+	var conf config.Config
+	outs, err := please.Build(conf.GetPlzPath(), m.plzConf.ModFile())
+	if err != nil {
+		return fmt.Errorf("Error while trying to locate go mod: %w", err)
+	}
+
+	if len(outs) != 1 {
+		return fmt.Errorf("Expected exacly one out from Plugin.Go.Modfile, got %v", len(outs))
+	}
+
+	modFile := strings.TrimPrefix(outs[0], "plz-out/gen/")
+
+	cmd := exec.Command("go", "get", module)
+	cmd.Dir = filepath.Dir(modFile)
+
+	return cmd.Run()
+}
+
+func (m *Migrate) replaceRules(updateGoMod bool, p *moduleParts) error {
 	download := ""
 	var version string
 	var patches []string
 	var licences []string
 	var name = strings.ReplaceAll(p.module, "/", "_")
+
+	if updateGoMod {
+		if err := m.addModuleToGoMod(p.module); err != nil {
+			return fmt.Errorf("`go get` failed: %w", err)
+		}
+	}
 
 	thirdPartyFile, err := m.graph.LoadFile(m.thirdPartyFolder)
 	if err != nil {

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -296,8 +296,9 @@ func (m *Migrate) addModulesToGoMod(modules []string, version *string) error {
 
 	// if there's exactly one module, go get that module at the version passed in
 	if len(modules) == 1 && version != nil {
-		fmt.Printf("command: go %s\nin dir %s\n", fmt.Sprintf("get %s@%s", modules[0], *version), filepath.Dir(modFile))
-		cmd := exec.Command("go", fmt.Sprintf("get %s@%s", modules[0], *version))
+		versionStr := strings.TrimSpace(*version)
+
+		cmd := exec.Command("go", "get", fmt.Sprintf("%s@%s", modules[0], versionStr))
 		cmd.Dir = filepath.Dir(modFile)
 
 		return cmd.Run()

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -240,7 +240,7 @@ func (m *Migrate) addModuleToGoMod(module string) error {
 	var conf config.Config
 	outs, err := please.Build(conf.GetPlzPath(), m.plzConf.ModFile())
 	if err != nil {
-		return fmt.Errorf("Error while trying to locate go mod: %w", err)
+		return fmt.Errorf("Could not find go mod file: %w", err)
 	}
 
 	if len(outs) != 1 {

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -249,7 +249,7 @@ func (m *Migrate) addModuleToGoMod(module string) error {
 	}
 
 	if len(outs) != 1 {
-		return fmt.Errorf("expected exacly one out from Plugin.Go.Modfile, got %v", len(outs))
+		return fmt.Errorf("expected exactly one out from Plugin.Go.Modfile, got %v", len(outs))
 	}
 
 	modFile := strings.TrimPrefix(outs[0], "plz-out/gen/")

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -234,7 +234,7 @@ func (m *Migrate) addNewRepoRule(name, version, download string, patches, licenc
 
 func (m *Migrate) addModuleToGoMod(module string) error {
 	if m.plzConf == nil {
-		return fmt.Errorf("no plzconfig found.")
+		return fmt.Errorf("no plzconfig found")
 	}
 
 	modFileTarget := m.plzConf.ModFile()

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -264,7 +264,7 @@ func (m *Migrate) replaceRules(updateGoMod bool, p *moduleParts) error {
 
 	if updateGoMod {
 		if err := m.addModuleToGoMod(p.module); err != nil {
-			return fmt.Errorf("`go get` failed: %w", err)
+			return fmt.Errorf("Error while trying to add module %s to go mod: %w", p.module, err)
 		}
 	}
 

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -149,15 +149,15 @@ func (m *Migrate) Migrate(write bool, updateGoMod bool, modules []string, paths 
 // with go_repo rules. We might get 0, 1, or multiple modules passed in on the command line.
 //
 // If 0, we'll do a go get on any modules that we find that are defined as go_modules (we'll pass
-// them all to go get at once to allow go to do its thing), and then migrate them to go_repo.
+// them all to go get at once to allow go to weave its version resolution magic), and then migrate
+// them to go_repo.
 //
-// If 1, we will try to pick up the version that is specified in the BUILD file, go get the module
-// @ that version (thereby adding all dependencies to the go.mod as well), and then migrate that
-// module as well as its dependencies in the BUILD file.
+// If 1, we will look to see if there is a version specified in the BUILD file under a corresponding
+// go_module, go get the module @ that version (thereby adding all dependencies to the go.mod as
+// well), and then migrate that module as well as its dependencies in the BUILD file.
 //
-// If multiple, we will do a go get on all of the passed-in modules at once to allow go get to weave
-// its version resolution magic, then we'll migrate all of the command-line modules and their
-// dependencies to go_repo.
+// If multiple, we will do a go get on all of the passed-in modules at once to allow go get to do
+// its thing, then we'll migrate all of the command-line modules and their dependencies to go_repo.
 func (m *Migrate) replaceRulesForModules(updateGoMod bool, modules []string) error {
 	// If we're not migrating specific modules, do all of them
 	if len(modules) == 0 {
@@ -177,9 +177,10 @@ func (m *Migrate) replaceRulesForModules(updateGoMod bool, modules []string) err
 				return fmt.Errorf("error replacing rule for module %s: %w", parts.module, err)
 			}
 		}
-
 	}
 
+	// The 1 module and multiple modules cases are handled together here because
+	// these both involve calls to migrateTransitively while the 0 modules case doesn't
 	if updateGoMod {
 		var version *string
 		if len(modules) == 1 {
@@ -196,7 +197,6 @@ func (m *Migrate) replaceRulesForModules(updateGoMod bool, modules []string) err
 	}
 
 	return m.migrateTransitively(modules)
-
 }
 
 func (m *Migrate) migrateTransitively(mods []string) error {

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -31,7 +31,7 @@ go_module(
 	}
 	m.graph.SetFile("third_party/go", thirdPartyFile)
 
-	err = m.Migrate(false, nil, "third_party/go")
+	err = m.Migrate(false, false, nil, "third_party/go")
 	require.NoError(t, err)
 
 	rule := edit.FindTargetByName(thirdPartyFile, "test")
@@ -97,7 +97,7 @@ go_module(
 	}
 	m.graph.SetFile("third_party/go", thirdPartyFile)
 
-	err = m.Migrate(false, nil, "third_party/go")
+	err = m.Migrate(false, false, nil, "third_party/go")
 	require.NoError(t, err)
 
 	repoRules := thirdPartyFile.Rules("go_repo")
@@ -150,7 +150,7 @@ go_module(
 	}
 	m.graph.SetFile("third_party/go", thirdPartyFile)
 
-	err = m.Migrate(false, nil, "third_party/go")
+	err = m.Migrate(false, false, nil, "third_party/go")
 	require.NoError(t, err)
 
 	repoRule := edit.FindTargetByName(thirdPartyFile, "test")
@@ -189,7 +189,7 @@ go_module(
 	}
 	m.graph.SetFile("third_party/go", thirdPartyFile)
 
-	err = m.Migrate(false, nil, "third_party/go", "third_party/go/kubernetes")
+	err = m.Migrate(false, false, nil, "third_party/go", "third_party/go/kubernetes")
 	require.NoError(t, err)
 
 	repoRule := edit.FindTargetByName(thirdPartyFile, "k8s.io_api")
@@ -238,7 +238,7 @@ go_module(
 
 	m.graph.SetFile("third_party/go", thirdPartyFile)
 
-	err = m.Migrate(false, []string{"k8s.io/api"}, "third_party/go")
+	err = m.Migrate(false, false, []string{"k8s.io/api"}, "third_party/go")
 	require.NoError(t, err)
 
 	apiRule := edit.FindTargetByName(thirdPartyFile, "api")

--- a/please/query_config.go
+++ b/please/query_config.go
@@ -39,9 +39,14 @@ func (c *Config) BuildFileNames() []string {
 }
 
 func (c *Config) ModFile() string {
+	if c == nil {
+		return ""
+	}
+
 	if len(c.Plugin.Go.Modfile) == 0 {
 		return ""
 	}
+
 	return c.Plugin.Go.Modfile[0]
 }
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -65,7 +65,7 @@ func (s *Sync) syncModFile(conf *config.Config, file *build.File, exitingRules m
 	}
 
 	if len(outs) != 1 {
-		return fmt.Errorf("expected exacly one out from Plugin.Go.Modfile, got %v", len(outs))
+		return fmt.Errorf("expected exactly one out from Plugin.Go.Modfile, got %v", len(outs))
 	}
 
 	modFile := outs[0]


### PR DESCRIPTION
Previously you had to do a `go get` on the module you wanted to migrate before `puku migrate`ing it. With this change we execute the `go get` internally.

It's done differently depending on how many modules are passed into `puku migrate`. If there are no modules passed in, all discovered `go_module`s are migrated, and we pass them all to `go get` to let `go` resolve the correct versions. If multiple modules are passed in, we again pass all of them to `go get`, and then transitively migrate them one by one. If exactly one module is passed in, we'll look to see if there's a `go_module` with a version tag for that module already in the build file, and if there is, we'll `go get` the module at that version, and then migrate it and its dependencies.