### PR TITLE
Refactor migrate, sync, and generate packages

### DIFF
--- a/cmd/puku/puku.go
+++ b/cmd/puku/puku.go
@@ -69,7 +69,7 @@ var log = logging.GetLogger()
 var funcs = map[string]func(conf *config.Config, plzConf *please.Config, orignalWD string) int{
 	"fmt": func(conf *config.Config, plzConf *please.Config, orignalWD string) int {
 		paths := work.MustExpandPaths(orignalWD, opts.Fmt.Args.Paths)
-		if err := generate.NewUpdate(true, plzConf).Update(paths...); err != nil {
+		if err := generate.Update(true, plzConf, paths...); err != nil {
 			log.Fatalf("%v", err)
 		}
 		return 0
@@ -83,14 +83,14 @@ var funcs = map[string]func(conf *config.Config, plzConf *please.Config, orignal
 	},
 	"lint": func(conf *config.Config, plzConf *please.Config, orignalWD string) int {
 		paths := work.MustExpandPaths(orignalWD, opts.Lint.Args.Paths)
-		if err := generate.NewUpdate(false, plzConf).Update(paths...); err != nil {
+		if err := generate.Update(false, plzConf, paths...); err != nil {
 			log.Fatalf("%v", err)
 		}
 		return 0
 	},
 	"watch": func(conf *config.Config, plzConf *please.Config, orignalWD string) int {
 		paths := work.MustExpandPaths(orignalWD, opts.Watch.Args.Paths)
-		if err := generate.NewUpdate(true, plzConf).Update(paths...); err != nil {
+		if err := generate.Update(true, plzConf, paths...); err != nil {
 			log.Fatalf("%v", err)
 		}
 

--- a/cmd/puku/puku.go
+++ b/cmd/puku/puku.go
@@ -107,7 +107,7 @@ var funcs = map[string]func(conf *config.Config, plzConf *please.Config, orignal
 			paths = []string{conf.GetThirdPartyDir()}
 		}
 		paths = work.MustExpandPaths(orignalWD, paths)
-		if err := migrate.New(conf, plzConf).Migrate(opts.Migrate.Write, opts.Migrate.UpdateGoMod, opts.Migrate.Args.Modules, paths...); err != nil {
+		if err := migrate.Migrate(conf, plzConf, opts.Migrate.Write, opts.Migrate.UpdateGoMod, opts.Migrate.Args.Modules, paths); err != nil {
 			log.Fatalf("%v", err)
 		}
 		return 0

--- a/cmd/puku/puku.go
+++ b/cmd/puku/puku.go
@@ -76,9 +76,7 @@ var funcs = map[string]func(conf *config.Config, plzConf *please.Config, orignal
 	},
 	"sync": func(conf *config.Config, plzConf *please.Config, orignalWD string) int {
 		g := graph.New(plzConf.BuildFileNames())
-		p := proxy.New(proxy.DefaultURL)
-		l := licences.New(p, g)
-		if err := sync.New(plzConf, g, l, opts.Sync.Write).Sync(); err != nil {
+		if err := sync.Sync(plzConf, g, opts.Sync.Write); err != nil {
 			log.Fatalf("%v", err)
 		}
 		return 0

--- a/generate/deps.go
+++ b/generate/deps.go
@@ -18,7 +18,7 @@ import (
 // the go sdk. Otherwise, it will return the build target for that dependency, or an error if it can't be resolved. If
 // the target can be resolved to a module that isn't currently added to this project, it will return the build target,
 // and record the new module in `u.newModules`. These should later be written to the build graph.
-func (u *Update) resolveImport(conf *config.Config, i string) (string, error) {
+func (u *updater) resolveImport(conf *config.Config, i string) (string, error) {
 	if t, ok := u.resolvedImports[i]; ok {
 		return t, nil
 	}
@@ -35,7 +35,7 @@ func (u *Update) resolveImport(conf *config.Config, i string) (string, error) {
 }
 
 // reallyResolveImport actually does the resolution of an import path to a build target.
-func (u *Update) reallyResolveImport(conf *config.Config, i string) (string, error) {
+func (u *updater) reallyResolveImport(conf *config.Config, i string) (string, error) {
 	if knownimports.IsInGoRoot(i) {
 		return "", nil
 	}
@@ -102,7 +102,7 @@ func (u *Update) reallyResolveImport(conf *config.Config, i string) (string, err
 
 // isInScope returns true when the given path is in scope of the current run i.e. if we are going to format the BUILD
 // file there.
-func (u *Update) isInScope(path string) bool {
+func (u *updater) isInScope(path string) bool {
 	for _, p := range u.paths {
 		if p == path {
 			return true
@@ -113,7 +113,7 @@ func (u *Update) isInScope(path string) bool {
 
 // localDep finds a dependency local to this repository, checking the BUILD file for a go_library target. Returns an
 // empty string when no target is found.
-func (u *Update) localDep(importPath string) (string, error) {
+func (u *updater) localDep(importPath string) (string, error) {
 	path := strings.Trim(strings.TrimPrefix(importPath, u.plzConf.ImportPath()), "/")
 	// If we're using GOPATH based resolution, we don't have a prefix to base whether a path is package local or not. In
 	// this case, we need to check if the directory exists. If it doesn't it's not a local import.

--- a/generate/deps_test.go
+++ b/generate/deps_test.go
@@ -38,7 +38,7 @@ func TestLocalDeps(t *testing.T) {
 	conf.Parse.BuildFileName = []string{"BUILD_FILE", "BUILD_FILE.plz"}
 	conf.Plugin.Go.ImportPath = []string{"github.com/some/module"}
 
-	u := NewUpdate(false, conf)
+	u := newUpdater(conf)
 
 	trgt, err := u.localDep("test_project/foo")
 	require.NoError(t, err)
@@ -82,7 +82,7 @@ func TestResolveImport(t *testing.T) {
 		},
 	}
 
-	u := Update{
+	u := updater{
 		plzConf:  &please.Config{},
 		installs: installs,
 		resolvedImports: map[string]string{

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -48,8 +48,6 @@ type updater struct {
 	licences *licences.Licenses
 }
 
-// newUpdaterWithGraph initialises a new updater struct. It's intended to be only used for
-// testing. In most instances the Update function should be called directly.
 func newUpdaterWithGraph(g *graph.Graph, conf *please.Config) *updater {
 	return &updater{
 		plzConf: conf,
@@ -57,6 +55,8 @@ func newUpdaterWithGraph(g *graph.Graph, conf *please.Config) *updater {
 	}
 }
 
+// newUpdater initialises a new updater struct. It's intended to be only used for testing (as is
+// newUpdaterWithGraph). In most instances the Update function should be called directly.
 func newUpdater(conf *please.Config) *updater {
 	g := graph.New(conf.BuildFileNames())
 

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -30,9 +30,9 @@ type Proxy interface {
 	ResolveDeps(mods, newMods []*proxy.Module) ([]*proxy.Module, error)
 }
 
-type Update struct {
-	plzConf              *please.Config
-	write, usingGoModule bool
+type updater struct {
+	plzConf       *please.Config
+	usingGoModule bool
 
 	graph *graph.Graph
 
@@ -48,29 +48,36 @@ type Update struct {
 	licences *licences.Licenses
 }
 
-func NewUpdate(write bool, plzConf *please.Config) *Update {
-	return NewUpdateWithGraph(write, plzConf, graph.New(plzConf.BuildFileNames()))
-}
-
-// NewUpdateWithGraph is like NewUpdate but lets us inject a graph which is useful to do testing.
-func NewUpdateWithGraph(write bool, conf *please.Config, g *graph.Graph) *Update {
-	p := proxy.New(proxy.DefaultURL)
-	l := licences.New(p, g)
-	return &Update{
-		proxy:           p,
-		licences:        l,
-		installs:        trie.New(),
-		write:           write,
-		resolvedImports: map[string]string{},
-		plzConf:         conf,
-		eval:            eval.New(glob.New()),
-		graph:           g,
+// newUpdaterWithGraph initialises a new updater struct. It's intended to be only used for
+// testing. In most instances the Update function should be called directly.
+func newUpdaterWithGraph(g *graph.Graph, conf *please.Config) *updater {
+	return &updater{
+		plzConf: conf,
+		graph:   g,
 	}
 }
 
-// Update updates an existing Please project. It may create new BUILD files, however it tries to respect existing build
-// rules, updating them as appropriate.
-func (u *Update) Update(paths ...string) error {
+func newUpdater(conf *please.Config) *updater {
+	g := graph.New(conf.BuildFileNames())
+
+	return newUpdaterWithGraph(g, conf)
+}
+
+func Update(write bool, plzConf *please.Config, paths ...string) error {
+	g := graph.New(plzConf.BuildFileNames())
+	p := proxy.New(proxy.DefaultURL)
+	l := licences.New(p, g)
+
+	u := &updater{
+		proxy:           p,
+		licences:        l,
+		installs:        trie.New(),
+		resolvedImports: map[string]string{},
+		plzConf:         plzConf,
+		eval:            eval.New(glob.New()),
+		graph:           g,
+	}
+
 	conf, err := config.ReadConfig(".")
 	if err != nil {
 		return err
@@ -85,10 +92,10 @@ func (u *Update) Update(paths ...string) error {
 		return err
 	}
 
-	return u.graph.FormatFiles(u.write, os.Stdout)
+	return u.graph.FormatFiles(write, os.Stdout)
 }
 
-func (u *Update) readAllModules(conf *config.Config) error {
+func (u *updater) readAllModules(conf *config.Config) error {
 	return filepath.WalkDir(conf.GetThirdPartyDir(), func(path string, info fs.DirEntry, err error) error {
 		for _, buildFileName := range u.plzConf.BuildFileNames() {
 			if info.Name() == buildFileName {
@@ -107,7 +114,7 @@ func (u *Update) readAllModules(conf *config.Config) error {
 }
 
 // readModules returns the defined third party modules in this project
-func (u *Update) readModules(file *build.File) error {
+func (u *updater) readModules(file *build.File) error {
 	addInstalls := func(targetName, modName string, installs []string) {
 		for _, install := range installs {
 			path := filepath.Join(modName, install)
@@ -142,7 +149,7 @@ func (u *Update) readModules(file *build.File) error {
 }
 
 // update loops through the provided paths, updating and creating any build rules it finds.
-func (u *Update) update(conf *config.Config) error {
+func (u *updater) update(conf *config.Config) error {
 	for _, path := range u.paths {
 		conf, err := config.ReadConfig(path)
 		if err != nil {
@@ -162,7 +169,7 @@ func (u *Update) update(conf *config.Config) error {
 	return u.addNewModules(conf)
 }
 
-func (u *Update) updateOne(conf *config.Config, path string) error {
+func (u *updater) updateOne(conf *config.Config, path string) error {
 	// Find all the files in the dir
 	sources, err := ImportDir(path)
 	if err != nil {
@@ -194,7 +201,7 @@ func (u *Update) updateOne(conf *config.Config, path string) error {
 	return u.updateDeps(conf, file, calls, rules, sources)
 }
 
-func (u *Update) addNewModules(conf *config.Config) error {
+func (u *updater) addNewModules(conf *config.Config) error {
 	file, err := u.graph.LoadFile(conf.GetThirdPartyDir())
 	if err != nil {
 		return err
@@ -244,7 +251,7 @@ func (u *Update) addNewModules(conf *config.Config) error {
 // goFiles contains a mapping of source files to their GoFile. This map might be missing entries from passedSources, if
 // the source doesn't actually exist. In which case, this should be removed from the rule, as the user likely deleted
 // the file.
-func (u *Update) allSources(conf *config.Config, r *rule, sourceMap map[string]*GoFile) (passedSources []string, goFiles map[string]*GoFile, err error) {
+func (u *updater) allSources(conf *config.Config, r *rule, sourceMap map[string]*GoFile) (passedSources []string, goFiles map[string]*GoFile, err error) {
 	srcs, err := u.eval.BuildSources(conf.GetPlzPath(), r.dir, r.Rule, r.SrcsAttr())
 	if err != nil {
 		return nil, nil, err
@@ -268,7 +275,7 @@ func (u *Update) allSources(conf *config.Config, r *rule, sourceMap map[string]*
 }
 
 // updateRuleDeps updates the dependencies of a build rule based on the imports of its sources
-func (u *Update) updateRuleDeps(conf *config.Config, rule *rule, rules []*rule, packageFiles map[string]*GoFile) error {
+func (u *updater) updateRuleDeps(conf *config.Config, rule *rule, rules []*rule, packageFiles map[string]*GoFile) error {
 	done := map[string]struct{}{}
 
 	// If the rule operates on non-go source files (e.g. *.proto for proto_library) then we should skip updating
@@ -367,7 +374,7 @@ func shorten(pkg, label string) string {
 }
 
 // readRulesFromFile reads the existing build rules from the BUILD file
-func (u *Update) readRulesFromFile(conf *config.Config, file *build.File, pkgDir string) ([]*rule, map[string]*build.Rule) {
+func (u *updater) readRulesFromFile(conf *config.Config, file *build.File, pkgDir string) ([]*rule, map[string]*build.Rule) {
 	ruleExprs := file.Rules("")
 	rules := make([]*rule, 0, len(ruleExprs))
 	calls := map[string]*build.Rule{}
@@ -386,7 +393,7 @@ func (u *Update) readRulesFromFile(conf *config.Config, file *build.File, pkgDir
 }
 
 // updateDeps updates the existing rules and creates any new rules in the BUILD file
-func (u *Update) updateDeps(conf *config.Config, file *build.File, ruleExprs map[string]*build.Rule, rules []*rule, sources map[string]*GoFile) error {
+func (u *updater) updateDeps(conf *config.Config, file *build.File, ruleExprs map[string]*build.Rule, rules []*rule, sources map[string]*GoFile) error {
 	for _, rule := range rules {
 		if _, ok := ruleExprs[rule.Name()]; !ok {
 			file.Stmt = append(file.Stmt, rule.Call)
@@ -400,7 +407,7 @@ func (u *Update) updateDeps(conf *config.Config, file *build.File, ruleExprs map
 
 // allocateSources allocates sources to rules. If there's no existing rule, a new rule will be created and returned
 // from this function
-func (u *Update) allocateSources(conf *config.Config, pkgDir string, sources map[string]*GoFile, rules []*rule) ([]*rule, error) {
+func (u *updater) allocateSources(conf *config.Config, pkgDir string, sources map[string]*GoFile, rules []*rule) ([]*rule, error) {
 	unallocated, err := u.unallocatedSources(sources, rules)
 	if err != nil {
 		return nil, err
@@ -456,7 +463,7 @@ func (u *Update) allocateSources(conf *config.Config, pkgDir string, sources map
 
 // rulePkg checks the first source it finds for a rule and returns the name from the "package name" directive at the top
 // of the file
-func (u *Update) rulePkg(conf *config.Config, srcs map[string]*GoFile, rule *rule) (string, error) {
+func (u *updater) rulePkg(conf *config.Config, srcs map[string]*GoFile, rule *rule) (string, error) {
 	// This is a safe bet if we can't use the source files to figure this out.
 	if rule.kind.NonGoSources {
 		return rule.Name(), nil
@@ -477,7 +484,7 @@ func (u *Update) rulePkg(conf *config.Config, srcs map[string]*GoFile, rule *rul
 }
 
 // unallocatedSources returns all the sources that don't already belong to a rule
-func (u *Update) unallocatedSources(srcs map[string]*GoFile, rules []*rule) ([]string, error) {
+func (u *updater) unallocatedSources(srcs map[string]*GoFile, rules []*rule) ([]string, error) {
 	var ret []string
 	for src := range srcs {
 		found := false

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -46,7 +46,7 @@ func TestAllocateSources(t *testing.T) {
 		},
 	}
 
-	u := &Update{plzConf: new(please.Config)}
+	u := &updater{plzConf: new(please.Config)}
 	conf := &config.Config{PleasePath: "plz"}
 	newRules, err := u.allocateSources(conf, "foo", files, rules)
 	require.NoError(t, err)
@@ -77,7 +77,7 @@ func TestAddingLibDepToTest(t *testing.T) {
 	foo.SetAttr(foo.SrcsAttr(), edit.NewStringList([]string{"foo.go"}))
 	fooTest.SetAttr(fooTest.SrcsAttr(), edit.NewStringList([]string{"foo_test.go"}))
 
-	u := &Update{plzConf: new(please.Config)}
+	u := &updater{plzConf: new(please.Config)}
 	conf := &config.Config{PleasePath: "plz"}
 	err := u.updateRuleDeps(conf, fooTest, []*rule{foo, fooTest}, files)
 	require.NoError(t, err)
@@ -124,7 +124,7 @@ func TestAllocateSourcesToCustomKind(t *testing.T) {
 		},
 	}
 
-	u := new(Update)
+	u := new(updater)
 	conf := &config.Config{PleasePath: "plz"}
 	newRules, err := u.allocateSources(conf, "foo", files, rules)
 	require.NoError(t, err)
@@ -154,7 +154,7 @@ func TestAllocateSourcesToNonGoKind(t *testing.T) {
 		},
 	}
 
-	u := new(Update)
+	u := new(updater)
 	u.plzConf = &please.Config{}
 	newRules, err := u.allocateSources(new(config.Config), "foo", files, rules)
 	require.NoError(t, err)
@@ -265,7 +265,7 @@ func TestUpdateDeps(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			plzConf := new(please.Config)
 			plzConf.Plugin.Go.ImportPath = []string{"github.com/this/module"}
-			u := &Update{
+			u := &updater{
 				modules:         tc.modules,
 				plzConf:         plzConf,
 				installs:        trie.New(),
@@ -303,7 +303,7 @@ func TestUpdateDeps(t *testing.T) {
 	}
 }
 
-func mustGetSources(t *testing.T, u *Update, rule *rule) []string {
+func mustGetSources(t *testing.T, u *updater, rule *rule) []string {
 	t.Helper()
 
 	srcs, err := u.eval.EvalGlobs(rule.dir, rule.Rule, rule.SrcsAttr())

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestMigrateGoModule(t *testing.T) {
-	m := &Migrate{
+	m := &migrator{
 		graph:            graph.New([]string{"BUILD"}),
 		thirdPartyFolder: "third_party/go",
 		moduleRules:      map[string]*moduleParts{},
@@ -31,7 +31,7 @@ go_module(
 	}
 	m.graph.SetFile("third_party/go", thirdPartyFile)
 
-	err = m.Migrate(false, false, nil, "third_party/go")
+	err = m.migrate(nil, []string{"third_party/go"}, false, false)
 	require.NoError(t, err)
 
 	rule := edit.FindTargetByName(thirdPartyFile, "test")
@@ -43,7 +43,7 @@ go_module(
 }
 
 func TestMigrateGoModuleWithParts(t *testing.T) {
-	m := &Migrate{
+	m := &migrator{
 		graph:            graph.New([]string{"BUILD"}),
 		thirdPartyFolder: "third_party/go",
 		moduleRules:      map[string]*moduleParts{},
@@ -97,7 +97,7 @@ go_module(
 	}
 	m.graph.SetFile("third_party/go", thirdPartyFile)
 
-	err = m.Migrate(false, false, nil, "third_party/go")
+	err = m.migrate(nil, []string{"third_party/go"}, false, false)
 	require.NoError(t, err)
 
 	repoRules := thirdPartyFile.Rules("go_repo")
@@ -125,7 +125,7 @@ go_module(
 }
 
 func TestModuleAlias(t *testing.T) {
-	m := &Migrate{
+	m := &migrator{
 		graph:            graph.New([]string{"BUILD"}),
 		thirdPartyFolder: "third_party/go",
 		moduleRules:      map[string]*moduleParts{},
@@ -150,7 +150,7 @@ go_module(
 	}
 	m.graph.SetFile("third_party/go", thirdPartyFile)
 
-	err = m.Migrate(false, false, nil, "third_party/go")
+	err = m.migrate(nil, []string{"third_party/go"}, false, false)
 	require.NoError(t, err)
 
 	repoRule := edit.FindTargetByName(thirdPartyFile, "test")
@@ -164,7 +164,7 @@ go_module(
 }
 
 func TestAliasesInOtherDirs(t *testing.T) {
-	m := &Migrate{
+	m := &migrator{
 		graph:            graph.New([]string{"BUILD"}),
 		thirdPartyFolder: "third_party/go",
 		moduleRules:      map[string]*moduleParts{},
@@ -189,7 +189,7 @@ go_module(
 	}
 	m.graph.SetFile("third_party/go", thirdPartyFile)
 
-	err = m.Migrate(false, false, nil, "third_party/go", "third_party/go/kubernetes")
+	err = m.migrate(nil, []string{"third_party/go", "third_party/go/kubernetes"}, false, false)
 	require.NoError(t, err)
 
 	repoRule := edit.FindTargetByName(thirdPartyFile, "k8s.io_api")
@@ -202,7 +202,7 @@ go_module(
 }
 
 func TestTransitiveMigration(t *testing.T) {
-	m := &Migrate{
+	m := &migrator{
 		graph:            graph.New([]string{"BUILD"}),
 		thirdPartyFolder: "third_party/go",
 		moduleRules:      map[string]*moduleParts{},
@@ -238,7 +238,7 @@ go_module(
 
 	m.graph.SetFile("third_party/go", thirdPartyFile)
 
-	err = m.Migrate(false, false, []string{"k8s.io/api"}, "third_party/go")
+	err = m.migrate([]string{"k8s.io/api"}, []string{"third_party/go"}, false, false)
 	require.NoError(t, err)
 
 	apiRule := edit.FindTargetByName(thirdPartyFile, "api")

--- a/proxy/BUILD
+++ b/proxy/BUILD
@@ -7,6 +7,7 @@ go_library(
         "//licences:all",
         "//sync/integration/syncmod:all",
         "//migrate:all",
+        "//sync:all",
     ],
     deps = [
         "///third_party/go/golang.org_x_mod//modfile",

--- a/sync/BUILD
+++ b/sync/BUILD
@@ -7,6 +7,7 @@ go_library(
         "//graph",
         "//licences",
         "//please",
+        "//proxy",
         "///third_party/go/github.com_please-build_buildtools//build",
         "///third_party/go/github.com_please-build_buildtools//labels",
         "///third_party/go/golang.org_x_mod//modfile",

--- a/sync/integration/syncmod/BUILD
+++ b/sync/integration/syncmod/BUILD
@@ -11,8 +11,6 @@ go_test(
         "//graph",
         "//please",
         "//third_party/go:testify",
-        "//licences",
-        "//proxy",
         "//sync",
     ],
 )

--- a/sync/integration/syncmod/sync_mod_test.go
+++ b/sync/integration/syncmod/sync_mod_test.go
@@ -11,9 +11,7 @@ import (
 
 	"github.com/please-build/puku/config"
 	"github.com/please-build/puku/graph"
-	"github.com/please-build/puku/licences"
 	"github.com/please-build/puku/please"
-	"github.com/please-build/puku/proxy"
 	"github.com/please-build/puku/sync"
 )
 
@@ -31,14 +29,10 @@ func TestModSync(t *testing.T) {
 	require.NoError(t, err)
 
 	g := graph.New(plzConf.BuildFileNames())
-
-	s := sync.New(plzConf, g, licences.New(proxy.New(proxy.DefaultURL), g), false)
+	err = sync.Sync(plzConf, g, false)
 	require.NoError(t, err)
 
-	err = s.Sync()
-	require.NoError(t, err)
-
-	thirdPartyBuildFile, err := g.LoadFile(conf.GetThirdPartyDir())
+	thirdPartyBuildFile, err := graph.New(plzConf.BuildFileNames()).LoadFile(conf.GetThirdPartyDir())
 	require.NoError(t, err)
 
 	expectedVers := readModFileVersions()

--- a/sync/integration/syncmod/sync_mod_test.go
+++ b/sync/integration/syncmod/sync_mod_test.go
@@ -32,7 +32,7 @@ func TestModSync(t *testing.T) {
 	err = sync.Sync(plzConf, g, false)
 	require.NoError(t, err)
 
-	thirdPartyBuildFile, err := graph.New(plzConf.BuildFileNames()).LoadFile(conf.GetThirdPartyDir())
+	thirdPartyBuildFile, err := g.LoadFile(conf.GetThirdPartyDir())
 	require.NoError(t, err)
 
 	expectedVers := readModFileVersions()

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -52,8 +52,7 @@ func (d *debouncer) wait() {
 	for p := range d.paths {
 		paths = append(paths, p)
 	}
-	u := generate.NewUpdate(true, d.config)
-	if err := u.Update(paths...); err != nil {
+	if err := generate.Update(true, d.config, paths...); err != nil {
 		log.Warningf("failed to update: %v", err)
 	} else {
 		log.Infof("Updated paths: %v ", strings.Join(paths, ", "))


### PR DESCRIPTION
This moves some things around to reduce leakage of package-specific runtime information that is never shared. It's now all contained within structs that are local to their respective packages, and the way to get at the core functionality of each package is through the functions `generate.Update()`, `migrate.Migrate()`, and `sync.Sync()`.