### PR TITLE
recursively look at base configs to determine if we should stop

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -123,7 +123,7 @@ func (c *Config) GetStop() bool {
 	if c.Stop {
 		return true
 	}
-	return (c.base != nil) && c.base.GetStop()
+	return c.base != nil && c.base.GetStop()
 }
 
 func (c *Config) GetKnownTarget(importPath string) string {

--- a/config/config.go
+++ b/config/config.go
@@ -120,7 +120,10 @@ func (c *Config) GetThirdPartyDir() string {
 }
 
 func (c *Config) GetStop() bool {
-	return c.Stop
+	if c.Stop {
+		return true
+	}
+	return (c.base != nil) && c.base.GetStop()
 }
 
 func (c *Config) GetKnownTarget(importPath string) string {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -42,3 +42,24 @@ func TestGetKind(t *testing.T) {
 		assert.Equal(t, kinds.Test, kind.Type)
 	})
 }
+
+func TestGetStop(t *testing.T) {
+	t.Run("when stop is true then dont stop", func(t *testing.T) {
+		c := Config{Stop: true}
+		assert.True(t, c.GetStop())
+	})
+
+	t.Run("when stop is false then stop", func(t *testing.T) {
+		c := Config{Stop: false}
+		assert.False(t, c.GetStop())
+	})
+
+	t.Run("when base stop is true then stop", func(t *testing.T) {
+		base := Config{Stop: true}
+		c := Config{base: &base, Stop: false}
+		assert.True(t, c.GetStop())
+
+		c = Config{base: &base, Stop: true}
+		assert.True(t, c.GetStop())
+	})
+}

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -151,7 +151,7 @@ func (u *updater) update(conf *config.Config) error {
 			return err
 		}
 
-		if conf.Stop {
+		if conf.GetStop() {
 			return nil
 		}
 


### PR DESCRIPTION
Previously we were just looking at the current directories stop. Now we look up the config paths to the root to ensure we don't have a stop true in one of them.