### PR TITLE
supporting binary expressions for srcs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+Version 1.7.2
+------------
+    * evaluating binary expressions correctly for srcs. (#109)
+
 Version 1.7.1
 ------------
     * resolve deps for go_repo to subrepo targets rather than its install

--- a/eval/BUILD
+++ b/eval/BUILD
@@ -13,6 +13,7 @@ go_library(
 go_test(
     name = "eval_test",
     srcs = ["eval_test.go"],
+    data = ["//:test_project"],
     deps = [
         ":eval",
         "///third_party/go/github.com_please-build_buildtools//build",

--- a/glob/glob.go
+++ b/glob/glob.go
@@ -25,7 +25,7 @@ func New() *Globber {
 // 1) globs should only match .go files as they're being used in go rules
 // 2) go rules will never depend on files outside the package dir, so we don't need to support **
 // 3) we don't want symlinks, directories and other non-regular files
-func (g *Globber) Glob(dir string, args *Args) ([]string, error) {
+func (g *Globber) Glob(dir string, args *Args) (map[string]struct{}, error) {
 	inc := map[string]struct{}{}
 	for _, i := range args.Include {
 		fs, err := g.glob(dir, i)
@@ -49,11 +49,7 @@ func (g *Globber) Glob(dir string, args *Args) ([]string, error) {
 		}
 	}
 
-	ret := make([]string, 0, len(inc))
-	for i := range inc {
-		ret = append(ret, i)
-	}
-	return ret, nil
+	return inc, nil
 }
 
 // glob matches all regular files in a directory based on a glob pattern

--- a/glob/glob_test.go
+++ b/glob/glob_test.go
@@ -15,7 +15,7 @@ func TestGlob(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		assert.ElementsMatch(t, []string{"bar_test.go"}, files)
+		assert.Equal(t, map[string]struct{}{"bar_test.go": {}}, files)
 	})
 
 	t.Run("excludes pattern", func(t *testing.T) {
@@ -25,6 +25,6 @@ func TestGlob(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		assert.ElementsMatch(t, []string{"main.go", "bar.go"}, files)
+		assert.Equal(t, map[string]struct{}{"main.go": {}, "bar.go": {}}, files)
 	})
 }


### PR DESCRIPTION
Previously binary expressions were ignored by puku. This meant statements like `glob(["*_test.go"]) + ["file.go"]` would not be evaluated properly. causing unnecessary churn and issues when evaluating if all sources were assigned.