### PR TITLE
simplify binary expression evaluation

### DIFF
--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -35,7 +35,6 @@ func TestParseGlob(t *testing.T) {
 			include: []string{"*.go"},
 			exclude: []string{"*_test.go"},
 		},
-
 		{
 			name: "ignores other args",
 			// Please has some other stuff we don't care about.
@@ -85,22 +84,13 @@ func TestEvalGlob(t *testing.T) {
 			code:     `glob(["mai*.go"]) + ["bar.go"]`,
 			expected: []string{"main.go", "bar.go"},
 		},
-		{
-			name:     "glob - strings",
-			code:     `glob(["*.go"]) - ["bar.go"]`,
-			expected: []string{"main.go", "bar_test.go"},
-		},
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			file, err := build.ParseBuild(test.name, []byte(test.code))
 			require.NoError(t, err)
 			require.Len(t, file.Stmt, 1)
-			ret, err := e.evalGlobs("test_project", file.Stmt[0])
-			got := make([]string, 0, len(ret))
-			for f := range ret {
-				got = append(got, f)
-			}
+			got, err := e.evalGlobs("test_project", file.Stmt[0])
 			require.NoError(t, err)
 			assert.ElementsMatch(t, test.expected, got)
 		})

--- a/glob/glob.go
+++ b/glob/glob.go
@@ -25,7 +25,7 @@ func New() *Globber {
 // 1) globs should only match .go files as they're being used in go rules
 // 2) go rules will never depend on files outside the package dir, so we don't need to support **
 // 3) we don't want symlinks, directories and other non-regular files
-func (g *Globber) Glob(dir string, args *Args) (map[string]struct{}, error) {
+func (g *Globber) Glob(dir string, args *Args) ([]string, error) {
 	inc := map[string]struct{}{}
 	for _, i := range args.Include {
 		fs, err := g.glob(dir, i)
@@ -49,7 +49,11 @@ func (g *Globber) Glob(dir string, args *Args) (map[string]struct{}, error) {
 		}
 	}
 
-	return inc, nil
+	ret := make([]string, 0, len(inc))
+	for i := range inc {
+		ret = append(ret, i)
+	}
+	return ret, nil
 }
 
 // glob matches all regular files in a directory based on a glob pattern

--- a/glob/glob_test.go
+++ b/glob/glob_test.go
@@ -15,7 +15,7 @@ func TestGlob(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		assert.Equal(t, map[string]struct{}{"bar_test.go": {}}, files)
+		assert.ElementsMatch(t, []string{"bar_test.go"}, files)
 	})
 
 	t.Run("excludes pattern", func(t *testing.T) {
@@ -25,6 +25,6 @@ func TestGlob(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		assert.Equal(t, map[string]struct{}{"main.go": {}, "bar.go": {}}, files)
+		assert.ElementsMatch(t, []string{"main.go", "bar.go"}, files)
 	})
 }


### PR DESCRIPTION
Since we can't do `["a", "b"] - ["a"]` the only operation that makes sense is + anyway so only handle that