### PR TITLE
Update Go

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -7,6 +7,7 @@ ImportPath = github.com/please-build/puku
 GoTool = //third_party/go:toolchain|go
 ModFile = //:mod
 RequireLicences = true
+Stdlib = //third_party/go:std
 
 [Alias "puku"]
 Cmd = run //cmd/puku --
@@ -18,4 +19,4 @@ Desc = Runs golangci-lint as done by our CI
 cmd = run //third_party/binary:golangci-lint -- run
 
 [BuildConfig]
-go-version = 1.21.4
+go-version = 1.22.3

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -2,5 +2,5 @@ plugin_repo(
     name = "go",
     owner = "please-build",
     plugin = "go-rules",
-    revision = "v1.11.1",
+    revision = "v1.17.3",
 )

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -7,6 +7,10 @@ go_toolchain(
     architectures = architectures,
 )
 
+go_stdlib(
+    name = "std",
+)
+
 go_repo(
     licences = ["ISC"],
     module = "github.com/davecgh/go-spew",


### PR DESCRIPTION
I'm getting errors saying `WARNING couldn't resolve "math/rand/v2"`; it seems pretty important that puku knows about the most recent stdlib packages available.

Also bump the plugin which was super out of date (and didn't work with 1.22 at that version)