### PR TITLE
Add a label to the build rule if a go repo target has a replace directive in go.mod

### DIFF
--- a/edit/edit.go
+++ b/edit/edit.go
@@ -176,5 +176,6 @@ func AddLabel(rule *build.Rule, label string) error {
 	}
 	// Add the new label
 	ruleLabelsList.List = append(ruleLabelsList.List, NewStringExpr(label))
+	rule.SetAttr("labels", ruleLabelsList)
 	return nil
 }

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -236,7 +236,7 @@ func (u *updater) addNewModules(conf *config.Config) error {
 		if err != nil {
 			return fmt.Errorf("failed to get license for mod %v: %v", mod.Module, err)
 		}
-		file.Stmt = append(file.Stmt, edit.NewGoRepoRule(mod.Module, mod.Version, "", ls))
+		file.Stmt = append(file.Stmt, edit.NewGoRepoRule(mod.Module, mod.Version, "", ls, []string{}))
 	}
 	return nil
 }

--- a/logging/BUILD
+++ b/logging/BUILD
@@ -6,6 +6,7 @@ go_library(
         "//cmd/puku:all",
         "//generate:all",
         "//graph:all",
+        "//sync:all",
         "//watch:all",
     ],
     deps = [

--- a/sync/BUILD
+++ b/sync/BUILD
@@ -6,6 +6,7 @@ go_library(
         "//edit",
         "//graph",
         "//licences",
+        "//logging",
         "//please",
         "//proxy",
         "///third_party/go/github.com_please-build_buildtools//build",

--- a/sync/integration/syncmod/BUILD
+++ b/sync/integration/syncmod/BUILD
@@ -12,5 +12,6 @@ go_test(
         "//please",
         "//third_party/go:testify",
         "//sync",
+        "///third_party/go/github.com_please-build_buildtools//build",
     ],
 )

--- a/sync/integration/syncmod/sync_mod_test.go
+++ b/sync/integration/syncmod/sync_mod_test.go
@@ -1,11 +1,11 @@
 package syncmod
 
 import (
-	"github.com/please-build/buildtools/build"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/please-build/buildtools/build"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/mod/modfile"
@@ -90,7 +90,7 @@ func TestModSync(t *testing.T) {
 
 func listLabels(rule *build.Rule) []string {
 	labelsExpr := rule.Attr("labels")
-	var labels []string
+	labels := make([]string, 0, len(labelsExpr.(*build.ListExpr).List))
 	for _, labelExpr := range labelsExpr.(*build.ListExpr).List {
 		labels = append(labels, labelExpr.(*build.StringExpr).Value)
 	}

--- a/sync/integration/syncmod/test_repo/go.mod
+++ b/sync/integration/syncmod/test_repo/go.mod
@@ -12,3 +12,5 @@ require (
 )
 
 replace github.com/bazelbuild/buildtools => github.com/peterebden/buildtools v1.6.0
+
+replace github.com/stretchr/testify => github.com/stretchr/testify v1.3.0

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -25,7 +25,7 @@ type syncer struct {
 	licences *licences.Licenses
 }
 
-const REPLACE_LABEL = "go_replace_directive"
+const ReplaceLabel = "go_replace_directive"
 
 func newSyncer(plzConf *please.Config, g *graph.Graph) *syncer {
 	p := proxy.New(proxy.DefaultURL)
@@ -125,7 +125,7 @@ func (s *syncer) syncModFile(conf *config.Config, file *build.File, existingRule
 				rule.SetAttr("version", edit.NewStringExpr(reqVersion))
 				// Add label for the replace directive
 				if matchingReplace != nil {
-					err := edit.AddLabel(rule, REPLACE_LABEL)
+					err := edit.AddLabel(rule, ReplaceLabel)
 					if err != nil {
 						log.Warningf("Failed to add replace label to %v: %v", req.Mod.Path, err)
 					}
@@ -142,13 +142,13 @@ func (s *syncer) syncModFile(conf *config.Config, file *build.File, existingRule
 
 		// If no replace directive, or replace directive is just replacing the version, add a simple rule
 		if matchingReplace == nil || matchingReplace.New.Path == req.Mod.Path {
-			file.Stmt = append(file.Stmt, edit.NewGoRepoRule(req.Mod.Path, reqVersion, "", ls, []string{REPLACE_LABEL}))
+			file.Stmt = append(file.Stmt, edit.NewGoRepoRule(req.Mod.Path, reqVersion, "", ls, []string{ReplaceLabel}))
 			continue
 		}
 
 		dl, dlName := edit.NewModDownloadRule(matchingReplace.New.Path, matchingReplace.New.Version, ls)
 		file.Stmt = append(file.Stmt, dl)
-		file.Stmt = append(file.Stmt, edit.NewGoRepoRule(req.Mod.Path, "", dlName, nil, []string{REPLACE_LABEL}))
+		file.Stmt = append(file.Stmt, edit.NewGoRepoRule(req.Mod.Path, "", dlName, nil, []string{ReplaceLabel}))
 	}
 
 	return nil

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -12,9 +12,12 @@ import (
 	"github.com/please-build/puku/edit"
 	"github.com/please-build/puku/graph"
 	"github.com/please-build/puku/licences"
+	"github.com/please-build/puku/logging"
 	"github.com/please-build/puku/please"
 	"github.com/please-build/puku/proxy"
 )
+
+var log = logging.GetLogger()
 
 type syncer struct {
 	plzConf  *please.Config
@@ -124,7 +127,7 @@ func (s *syncer) syncModFile(conf *config.Config, file *build.File, existingRule
 				if matchingReplace != nil {
 					err := edit.AddLabel(rule, REPLACE_LABEL)
 					if err != nil {
-						return fmt.Errorf("failed to add replace label to %v: %v", req.Mod.Path, err)
+						log.Warningf("Failed to add replace label to %v: %v", req.Mod.Path, err)
 					}
 				}
 				// No other changes needed

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -1,11 +1,12 @@
 package sync
 
 import (
+	"os"
 	"fmt"
+	
 	"github.com/please-build/buildtools/build"
 	"github.com/please-build/buildtools/labels"
 	"golang.org/x/mod/modfile"
-	"os"
 
 	"github.com/please-build/puku/config"
 	"github.com/please-build/puku/edit"

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -1,9 +1,9 @@
 package sync
 
 import (
-	"os"
 	"fmt"
-	
+	"os"
+
 	"github.com/please-build/buildtools/build"
 	"github.com/please-build/buildtools/labels"
 	"golang.org/x/mod/modfile"


### PR DESCRIPTION
We're thinking it would be useful to have a label on the build rule if a go module is pinned with a replace directive.

This way we can see which versions are pinned when checking through which need updating and such