### PR TITLE
Remove replace directive labels when not needed

### DIFF
--- a/sync/integration/syncmod/test_repo/third_party/go/BUILD_FILE
+++ b/sync/integration/syncmod/test_repo/third_party/go/BUILD_FILE
@@ -6,16 +6,22 @@ go_repo(
 )
 
 go_repo(
+    labels = [
+      "example_label",
+      "go_replace_directive",
+    ],
     module = "github.com/davecgh/go-spew",
     version = "v0.0.1",
 )
 
 go_repo(
+    labels = ["example_label"],
     module = "github.com/pmezard/go-difflib",
     version = "v0.0.1",
 )
 
 go_repo(
+    labels = ["go_replace_directive"],
     module = "github.com/stretchr/objx",
     version = "v0.0.1",
 )

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -148,7 +148,11 @@ func (s *syncer) syncModFile(conf *config.Config, file *build.File, existingRule
 
 		// If no replace directive, or replace directive is just replacing the version, add a simple rule
 		if matchingReplace == nil || matchingReplace.New.Path == req.Mod.Path {
-			file.Stmt = append(file.Stmt, edit.NewGoRepoRule(req.Mod.Path, reqVersion, "", ls, []string{ReplaceLabel}))
+			replaceLabels := []string{}
+			if matchingReplace != nil {
+				replaceLabels = []string{ReplaceLabel}
+			}
+			file.Stmt = append(file.Stmt, edit.NewGoRepoRule(req.Mod.Path, reqVersion, "", ls, replaceLabels))
 			continue
 		}
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -113,7 +113,6 @@ func (s *syncer) syncModFile(conf *config.Config, file *build.File, existingRule
 
 	// Check all modules listed in go.mod
 	for _, req := range f.Require {
-
 		// Find any matching replace directive
 		var matchingReplace *modfile.Replace
 		for _, replace := range f.Replace {

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -104,8 +104,11 @@ func (s *syncer) syncModFile(conf *config.Config, file *build.File, existingRule
 	}
 
 	// Remove "go_replace_directive" label from all existing rules, before re-adding it only where appropriate
-	for _, rule := range existingRules {
-		edit.RemoveLabel(rule, ReplaceLabel)
+	for modPath, rule := range existingRules {
+		err = edit.RemoveLabel(rule, ReplaceLabel)
+		if err != nil {
+			log.Warningf("Failed to remove replace label from %v: %v", modPath, err)
+		}
 	}
 
 	// Check all modules listed in go.mod

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -103,6 +103,12 @@ func (s *syncer) syncModFile(conf *config.Config, file *build.File, existingRule
 		return err
 	}
 
+	// Remove "go_replace_directive" label from all existing rules, before re-adding it only where appropriate
+	for _, rule := range existingRules {
+		edit.RemoveLabel(rule, ReplaceLabel)
+	}
+
+	// Check all modules listed in go.mod
 	for _, req := range f.Require {
 		reqVersion := req.Mod.Version
 		var matchingReplace *modfile.Replace


### PR DESCRIPTION
The previous PR I made, #114, added `go_replace_directive` labels to all go_repo rules which had a replace directive in the go.mod file. But it did not remove that label from any rules which do not have a go.mod replace directive.

(Also, it added go_replace_directive labels to any new rules without replace directives, whoops)

Extended tests, and fixed functionality to ensure that go_replace_directive labels are removed from all rules which lack replace directives in the go.mod file