### PR TITLE
Move the rule helpers out into the edit package

### DIFF
--- a/edit/BUILD
+++ b/edit/BUILD
@@ -1,6 +1,10 @@
 go_library(
     name = "edit",
-    srcs = ["edit.go"],
+    srcs = [
+        "build_targets.go",
+        "edit.go",
+        "rule.go",
+    ],
     visibility = [
         "//e2e/codegen:all",
         "//e2e/tests/codegen:all",
@@ -15,12 +19,16 @@ go_library(
     deps = [
         "///third_party/go/github.com_please-build_buildtools//build",
         "///third_party/go/github.com_please-build_buildtools//edit",
+        "//kinds",
     ],
 )
 
 go_test(
     name = "edit_test",
-    srcs = ["edit_test.go"],
+    srcs = [
+        "build_target_test.go",
+        "edit_test.go",
+    ],
     deps = [
         ":edit",
         "///third_party/go/github.com_please-build_buildtools//build",

--- a/edit/build_target_test.go
+++ b/edit/build_target_test.go
@@ -1,8 +1,9 @@
 package edit
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBuildTarget(t *testing.T) {

--- a/edit/build_target_test.go
+++ b/edit/build_target_test.go
@@ -1,0 +1,29 @@
+package edit
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestBuildTarget(t *testing.T) {
+	local := BuildTarget("foo", "", "")
+	assert.Equal(t, local, ":foo")
+
+	root := BuildTarget("foo", ".", "")
+	assert.Equal(t, "//:foo", root)
+
+	pkg := BuildTarget("foo", "pkg", "")
+	assert.Equal(t, "//pkg:foo", pkg)
+
+	pkgSameName := BuildTarget("foo", "foo", "")
+	assert.Equal(t, "//foo", pkgSameName)
+
+	subrepo := BuildTarget("foo", "pkg", "repo")
+	assert.Equal(t, "///repo//pkg:foo", subrepo)
+
+	subrepoRoot := BuildTarget("foo", ".", "repo")
+	assert.Equal(t, "///repo//:foo", subrepoRoot)
+
+	subrepoRootAlt := BuildTarget("foo", "", "repo")
+	assert.Equal(t, "///repo//:foo", subrepoRootAlt)
+}

--- a/edit/build_targets.go
+++ b/edit/build_targets.go
@@ -1,0 +1,49 @@
+package edit
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func SubrepoTarget(module, thirdPartyFolder, packageName string) string {
+	subrepoName := SubrepoName(module, thirdPartyFolder)
+
+	name := filepath.Base(packageName)
+	if packageName == "" {
+		name = filepath.Base(module)
+	}
+
+	return BuildTarget(name, packageName, subrepoName)
+}
+
+func SubrepoName(module, thirdPartyFolder string) string {
+	return filepath.Join(thirdPartyFolder, strings.ReplaceAll(module, "/", "_"))
+}
+
+func BuildTarget(name, pkgDir, subrepo string) string {
+	bs := new(strings.Builder)
+	if subrepo != "" {
+		bs.WriteString("///")
+		bs.WriteString(subrepo)
+	}
+
+	if pkgDir != "" || subrepo != "" {
+		bs.WriteString("//")
+	}
+
+	if pkgDir == "." {
+		pkgDir = ""
+	}
+
+	if pkgDir != "" {
+		bs.WriteString(pkgDir)
+		if filepath.Base(pkgDir) != name {
+			bs.WriteString(":")
+			bs.WriteString(name)
+		}
+	} else {
+		bs.WriteString(":")
+		bs.WriteString(name)
+	}
+	return bs.String()
+}

--- a/edit/rule.go
+++ b/edit/rule.go
@@ -1,21 +1,20 @@
-package generate
+package edit
 
 import (
 	"github.com/please-build/buildtools/build"
 
-	"github.com/please-build/puku/edit"
 	"github.com/please-build/puku/kinds"
 )
 
-type rule struct {
-	dir  string
-	kind *kinds.Kind
+type Rule struct {
+	Dir  string
+	Kind *kinds.Kind
 	*build.Rule
 }
 
-// setOrDeleteAttr will make sure the attribute with the given name matches the values passed in. It will keep the
+// SetOrDeleteAttr will make sure the attribute with the given name matches the values passed in. It will keep the
 // existing expressions in the list to maintain things like comments.
-func (rule *rule) setOrDeleteAttr(name string, values []string) {
+func (rule *Rule) SetOrDeleteAttr(name string, values []string) {
 	if len(values) == 0 {
 		rule.DelAttr(name)
 		return
@@ -49,7 +48,7 @@ func (rule *rule) setOrDeleteAttr(name string, values []string) {
 	// Loops through the value adding any new values that didn't used to be there
 	for _, v := range values {
 		if _, done := done[v]; !done {
-			exprs = append(exprs, edit.NewStringExpr(v))
+			exprs = append(exprs, NewStringExpr(v))
 		}
 	}
 
@@ -57,21 +56,21 @@ func (rule *rule) setOrDeleteAttr(name string, values []string) {
 	rule.SetAttr(name, listExpr)
 }
 
-func (rule *rule) isTest() bool {
-	return rule.kind.Type == kinds.Test
+func (rule *Rule) IsTest() bool {
+	return rule.Kind.Type == kinds.Test
 }
 
-func (rule *rule) SrcsAttr() string {
-	return rule.kind.SrcsAttr
+func (rule *Rule) SrcsAttr() string {
+	return rule.Kind.SrcsAttr
 }
 
-func (rule *rule) addSrc(src string) {
+func (rule *Rule) AddSrc(src string) {
 	srcsAttr := rule.SrcsAttr()
 	srcs := rule.AttrStrings(srcsAttr)
-	rule.setOrDeleteAttr(srcsAttr, append(srcs, src))
+	rule.SetOrDeleteAttr(srcsAttr, append(srcs, src))
 }
 
-func (rule *rule) removeSrc(rem string) {
+func (rule *Rule) RemoveSrc(rem string) {
 	srcsAttr := rule.SrcsAttr()
 	srcs := rule.AttrStrings(srcsAttr)
 	set := make([]string, 0, len(srcs))
@@ -80,43 +79,21 @@ func (rule *rule) removeSrc(rem string) {
 			set = append(set, src)
 		}
 	}
-	rule.setOrDeleteAttr(srcsAttr, set)
+	rule.SetOrDeleteAttr(srcsAttr, set)
 }
 
-func (rule *rule) setExternal() {
-	rule.SetAttr("external", &build.Ident{Name: "True"})
-}
-
-func (rule *rule) localLabel() string {
+func (rule *Rule) LocalLabel() string {
 	return ":" + rule.Name()
 }
 
-func (rule *rule) label() string {
-	return BuildTarget(rule.Name(), rule.dir, "")
+func (rule *Rule) Label() string {
+	return BuildTarget(rule.Name(), rule.Dir, "")
 }
 
-func (rule *rule) isExternal() bool {
-	if !rule.isTest() {
-		return false
-	}
-
-	external := rule.Attr("external")
-	if external == nil {
-		return false
-	}
-
-	ident, ok := external.(*build.Ident)
-	if !ok {
-		return false
-	}
-
-	return ident.Name == "True"
-}
-
-func newRule(r *build.Rule, kindType *kinds.Kind, pkgDir string) *rule {
-	return &rule{
-		dir:  pkgDir,
-		kind: kindType,
+func NewRule(r *build.Rule, kindType *kinds.Kind, pkgDir string) *Rule {
+	return &Rule{
+		Dir:  pkgDir,
+		Kind: kindType,
 		Rule: r,
 	}
 }

--- a/generate/deps.go
+++ b/generate/deps.go
@@ -2,7 +2,6 @@ package generate
 
 import (
 	"fmt"
-	"github.com/please-build/puku/edit"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +9,7 @@ import (
 	"github.com/please-build/buildtools/build"
 
 	"github.com/please-build/puku/config"
+	"github.com/please-build/puku/edit"
 	"github.com/please-build/puku/fs"
 	"github.com/please-build/puku/kinds"
 	"github.com/please-build/puku/knownimports"

--- a/generate/deps.go
+++ b/generate/deps.go
@@ -2,6 +2,7 @@ package generate
 
 import (
 	"fmt"
+	"github.com/please-build/puku/edit"
 	"os"
 	"path/filepath"
 	"strings"
@@ -145,7 +146,7 @@ func (u *updater) localDep(importPath string) (string, error) {
 	// If we can't find the lib target, and the target package is in scope for us to potentially generate it, check if
 	// we are going to generate it.
 	if len(libTargets) != 0 {
-		return BuildTarget(libTargets[0].Name(), path, ""), nil
+		return edit.BuildTarget(libTargets[0].Name(), path, ""), nil
 	}
 
 	if !u.isInScope(importPath) {
@@ -163,7 +164,7 @@ func (u *updater) localDep(importPath string) (string, error) {
 	// If there are any non-test sources, then we will generate a go_library here later on. Return that target name.
 	for _, f := range files {
 		if !f.IsTest() {
-			return BuildTarget(filepath.Base(importPath), path, ""), nil
+			return edit.BuildTarget(filepath.Base(importPath), path, ""), nil
 		}
 	}
 	return "", nil
@@ -178,7 +179,7 @@ func depTarget(modules []string, importPath, thirdPartyFolder string) string {
 	}
 
 	packageName := strings.TrimPrefix(strings.TrimPrefix(importPath, module), "/")
-	return SubrepoTarget(module, thirdPartyFolder, packageName)
+	return edit.SubrepoTarget(module, thirdPartyFolder, packageName)
 }
 
 func moduleForPackage(modules []string, importPath string) string {
@@ -190,47 +191,4 @@ func moduleForPackage(modules []string, importPath string) string {
 		}
 	}
 	return module
-}
-
-func SubrepoTarget(module, thirdPartyFolder, packageName string) string {
-	subrepoName := SubrepoName(module, thirdPartyFolder)
-
-	name := filepath.Base(packageName)
-	if packageName == "" {
-		name = filepath.Base(module)
-	}
-
-	return BuildTarget(name, packageName, subrepoName)
-}
-
-func SubrepoName(module, thirdPartyFolder string) string {
-	return filepath.Join(thirdPartyFolder, strings.ReplaceAll(module, "/", "_"))
-}
-
-func BuildTarget(name, pkgDir, subrepo string) string {
-	bs := new(strings.Builder)
-	if subrepo != "" {
-		bs.WriteString("///")
-		bs.WriteString(subrepo)
-	}
-
-	if pkgDir != "" || subrepo != "" {
-		bs.WriteString("//")
-	}
-
-	if pkgDir == "." {
-		pkgDir = ""
-	}
-
-	if pkgDir != "" {
-		bs.WriteString(pkgDir)
-		if filepath.Base(pkgDir) != name {
-			bs.WriteString(":")
-			bs.WriteString(name)
-		}
-	} else {
-		bs.WriteString(":")
-		bs.WriteString(name)
-	}
-	return bs.String()
 }

--- a/generate/deps_test.go
+++ b/generate/deps_test.go
@@ -50,29 +50,6 @@ func TestLocalDeps(t *testing.T) {
 	assert.Equal(t, "//test_project/foo:bar", trgt)
 }
 
-func TestBuildTarget(t *testing.T) {
-	local := BuildTarget("foo", "", "")
-	assert.Equal(t, local, ":foo")
-
-	root := BuildTarget("foo", ".", "")
-	assert.Equal(t, "//:foo", root)
-
-	pkg := BuildTarget("foo", "pkg", "")
-	assert.Equal(t, "//pkg:foo", pkg)
-
-	pkgSameName := BuildTarget("foo", "foo", "")
-	assert.Equal(t, "//foo", pkgSameName)
-
-	subrepo := BuildTarget("foo", "pkg", "repo")
-	assert.Equal(t, "///repo//pkg:foo", subrepo)
-
-	subrepoRoot := BuildTarget("foo", ".", "repo")
-	assert.Equal(t, "///repo//:foo", subrepoRoot)
-
-	subrepoRootAlt := BuildTarget("foo", "", "repo")
-	assert.Equal(t, "///repo//:foo", subrepoRootAlt)
-}
-
 func TestResolveImport(t *testing.T) {
 	installs := trie.New()
 	installs.Add("installed", "//third_party/go:installed")

--- a/kinds/BUILD
+++ b/kinds/BUILD
@@ -4,6 +4,7 @@ go_library(
     visibility = [
         "//config",
         "//config:all",
+        "//edit:all",
         "//eval:all",
         "//generate:all",
     ],

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/please-build/puku/config"
 	"github.com/please-build/puku/edit"
-	"github.com/please-build/puku/generate"
 	"github.com/please-build/puku/graph"
 	"github.com/please-build/puku/licences"
 	"github.com/please-build/puku/options"
@@ -130,11 +129,11 @@ func binaryAlias(module, thirdPartyDir string, part *pkgRule) (*build.Rule, erro
 	installs := part.rule.AttrStrings("install")
 
 	if len(installs) == 0 {
-		rule.SetAttr("srcs", edit.NewStringList([]string{generate.SubrepoTarget(module, thirdPartyDir, "")}))
+		rule.SetAttr("srcs", edit.NewStringList([]string{edit.SubrepoTarget(module, thirdPartyDir, "")}))
 	} else if len(installs) == 1 {
-		rule.SetAttr("srcs", edit.NewStringList([]string{generate.SubrepoTarget(module, thirdPartyDir, installs[0])}))
+		rule.SetAttr("srcs", edit.NewStringList([]string{edit.SubrepoTarget(module, thirdPartyDir, installs[0])}))
 	} else {
-		return nil, fmt.Errorf("too many installs to binary rule: %s", generate.BuildTarget(rule.Name(), part.pkg, ""))
+		return nil, fmt.Errorf("too many installs to binary rule: %s", edit.BuildTarget(rule.Name(), part.pkg, ""))
 	}
 
 	return rule, nil
@@ -346,7 +345,7 @@ func (m *migrator) replaceRules(p *moduleParts) error {
 	// We need to use a go_mod_download if the download rule is downloading the module using a different path than the
 	// import path of the module e.g. for when we've forked a module similar to how replace works in go.mods.
 	if p.download != nil && p.module != p.download.rule.AttrString("module") {
-		download = labels.Shorten(generate.BuildTarget(p.download.rule.Name(), p.download.pkg, ""), m.thirdPartyFolder)
+		download = labels.Shorten(edit.BuildTarget(p.download.rule.Name(), p.download.pkg, ""), m.thirdPartyFolder)
 		if len(p.parts) == 1 {
 			name = p.parts[0].rule.Name()
 		}
@@ -447,8 +446,8 @@ func (m *migrator) replacePartsWithAliases(p *moduleParts) error {
 		return nil
 	}
 	for _, part := range p.parts {
-		subrepoName := generate.SubrepoName(p.module, m.thirdPartyFolder)
-		installRule := generate.BuildTarget("installs", ".", subrepoName)
+		subrepoName := edit.SubrepoName(p.module, m.thirdPartyFolder)
+		installRule := edit.BuildTarget("installs", ".", subrepoName)
 
 		rule := edit.NewRuleExpr("filegroup", part.rule.Name())
 

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -2,5 +2,5 @@ plugin_repo(
     name = "go",
     owner = "please-build",
     plugin = "go-rules",
-    revision = "v1.17.3",
+    revision = "v1.21.2",
 )


### PR DESCRIPTION
This stuff probably doesn't really make sense in the generate package. They're just useful helpers. 

If we introduce other languages, these should be in a common place that each language updater can use them. 