### PR TITLE
Simplify toolchain setup

### DIFF
--- a/.github/workflows/puku.yaml
+++ b/.github/workflows/puku.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Build puku
-        run: ./pleasew build -p -v notice --profile release //package:release_files
+        run: ./pleasew build -p -v notice //package:release_files
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.plzconfig.release
+++ b/.plzconfig.release
@@ -1,2 +1,0 @@
-[Plugin "go"]
-GoTool = //package:release_toolchain|go

--- a/knownimports/BUILD
+++ b/knownimports/BUILD
@@ -1,10 +1,8 @@
-root = f"third_party/go/toolchain/pkg/{CONFIG.OS}_{CONFIG.ARCH}"
-
 genrule(
     name = "go_root_packages",
-    srcs = ["//third_party/go:toolchain"],
+    srcs = ["//third_party/go:std"],
     outs = ["go_root_packages"],
-    cmd = f'find {root} -name "*.a" | sed -e s=^{root}/== | sed -e s="\.a\$"== > $OUT',
+    cmd = 'find $SRCS -name "*.a" | sed -re s=^third_party/go/std/pkg/[^/]+_[^/]+/== | sed -e s="\.a\$"== > $OUT',
     labels = ["codegen"],
 )
 

--- a/knownimports/known_imports.go
+++ b/knownimports/known_imports.go
@@ -32,8 +32,7 @@ func IsInGoRoot(i string) bool {
 	if strings.HasPrefix(i, "crypto/") {
 		return true
 	}
-	_, ok := goRootImports[i]
-	if ok {
+	if _, ok := goRootImports[i]; ok {
 		return true
 	}
 

--- a/package/BUILD
+++ b/package/BUILD
@@ -8,12 +8,6 @@ filegroup(
 
 subinclude(":architectures")
 
-go_toolchain(
-    name = "release_toolchain",
-    architectures = architectures,
-    version = CONFIG.GO_VERSION,
-)
-
 def cross_compile(version, arch):
     return build_rule(
         name = f"puku_{arch}",

--- a/package/BUILD
+++ b/package/BUILD
@@ -1,12 +1,12 @@
 subinclude("//:puku_version")
 
-filegroup(
-    name = "architectures",
-    srcs = ["architectures.build_defs"],
-    visibility = ["PUBLIC"],
-)
-
-subinclude(":architectures")
+architectures = [
+    "darwin_amd64",
+    "darwin_arm64",
+    "freebsd_amd64",
+    "linux_amd64",
+    "linux_arm64",
+]
 
 def cross_compile(version, arch):
     return build_rule(

--- a/package/architectures.build_defs
+++ b/package/architectures.build_defs
@@ -1,7 +1,0 @@
-architectures = [
-    "darwin_amd64",
-    "darwin_arm64",
-    "freebsd_amd64",
-    "linux_amd64",
-    "linux_arm64",
-]

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -1,4 +1,4 @@
-subinclude("///go//build_defs:go", "//package:architectures")
+subinclude("///go//build_defs:go")
 
 go_toolchain(
     name = "toolchain",

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -2,8 +2,8 @@ subinclude("///go//build_defs:go", "//package:architectures")
 
 go_toolchain(
     name = "toolchain",
-    architectures = architectures,
     version = CONFIG.GO_VERSION,
+    install_std = False,
 )
 
 go_stdlib(


### PR DESCRIPTION
We can use the stdlib instead to find the known packages, and we don't need to maintain the build defs file for the architectures because each stdlib will just get built on demand for that arch.

Have manually checked the known packages file against master, both hash the same (`7dc0e2400b15abcd5992f01125168ecf44b303cebe707cf447f641d783218d60`, not that anyone cares)