### PR TITLE
Correctly handle `//...` as a visibility identifier

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/please-build/buildtools/build"
@@ -252,15 +253,7 @@ func isSubpackage(basePkg, pkg string) bool {
 	}
 	basePkgParts := strings.Split(basePkg, "/")
 	pkgParts := strings.Split(pkg, "/")
-	if len(basePkgParts) > len(pkgParts) {
-		return false
-	}
-	for i := range basePkgParts {
-		if basePkgParts[i] != pkgParts[i] {
-			return false
-		}
-	}
-	return true
+	return slices.Equal(basePkgParts, pkgParts[:len(basePkgParts)])
 }
 
 type nopCloser struct {

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -163,28 +163,71 @@ go_library(
 }
 
 func TestCheckVisibility(t *testing.T) {
-	label := labels.Parse("//foo/bar:baz")
-	t.Run("matches exactly", func(t *testing.T) {
-		assert.True(t, checkVisibility(label, []string{"//foo/bar:baz"}))
-	})
-	t.Run("matches all psudo-label", func(t *testing.T) {
-		assert.True(t, checkVisibility(label, []string{"//foo/bar:all"}))
-	})
-	t.Run("matches PUBLIC", func(t *testing.T) {
-		assert.True(t, checkVisibility(label, []string{"PUBLIC"}))
-	})
-	t.Run("matches root package wildcard", func(t *testing.T) {
-		assert.True(t, checkVisibility(label, []string{"//..."}))
-	})
-	t.Run("matches package wildcard", func(t *testing.T) {
-		assert.True(t, checkVisibility(label, []string{"//foo/..."}))
-	})
-	t.Run("doesnt match a different package wildcard", func(t *testing.T) {
-		assert.False(t, checkVisibility(label, []string{"//bar/..."}))
-	})
-	t.Run("doesnt match a different package", func(t *testing.T) {
-		assert.False(t, checkVisibility(label, []string{"//bar:all"}))
-	})
+	assert := assert.New(t)
+	for _, test := range []struct {
+		description string
+		label       string
+		visibility  []string
+		expected    bool
+	}{
+		{
+			description: "Exact match",
+			label:       "//foo/bar:baz",
+			visibility:  []string{"//foo/bar:baz"},
+			expected:    true,
+		},
+		{
+			description: "Matches :all pseudo-label for same package",
+			label:       "//foo/bar:baz",
+			visibility:  []string{"//foo/bar:all"},
+			expected:    true,
+		},
+		{
+			description: "Doesn't match :all pseudo-label for different package",
+			label:       "//foo/bar:baz",
+			visibility:  []string{"//foo/baz:all"},
+			expected:    false,
+		},
+		{
+			description: "Matches PUBLIC pseudo-label",
+			label:       "//foo/bar:baz",
+			visibility:  []string{"PUBLIC"},
+			expected:    true,
+		},
+		{
+			description: "Matches top-level package's wildcard",
+			label:       "//foo/bar:baz",
+			visibility:  []string{"//..."},
+			expected:    true,
+		},
+		{
+			description: "Matches top-level package's wildcard for top-level label",
+			label:       "//:baz",
+			visibility:  []string{"//..."},
+			expected:    true,
+		},
+		{
+			description: "Matches parent package's wildcard",
+			label:       "//foo/bar:baz",
+			visibility:  []string{"//foo/..."},
+			expected:    true,
+		},
+		{
+			description: "Matches same package's wildcard",
+			label:       "//foo/bar:baz",
+			visibility:  []string{"//foo/bar/..."},
+			expected:    true,
+		},
+		{
+			description: "Doesn't match wildcard of a package with different parent",
+			label:       "//foo/bar:baz",
+			visibility:  []string{"//bar/..."},
+			expected:    false,
+		},
+	} {
+		label := labels.Parse(test.label)
+		assert.Equal(test.expected, checkVisibility(label, test.visibility), test.description)
+	}
 }
 
 func TestGetDefaultVisibilityFromFile(t *testing.T) {

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -173,10 +173,12 @@ func TestCheckVisibility(t *testing.T) {
 	t.Run("matches PUBLIC", func(t *testing.T) {
 		assert.True(t, checkVisibility(label, []string{"PUBLIC"}))
 	})
+	t.Run("matches root package wildcard", func(t *testing.T) {
+		assert.True(t, checkVisibility(label, []string{"//..."}))
+	})
 	t.Run("matches package wildcard", func(t *testing.T) {
 		assert.True(t, checkVisibility(label, []string{"//foo/..."}))
 	})
-
 	t.Run("doesnt match a different package wildcard", func(t *testing.T) {
 		assert.False(t, checkVisibility(label, []string{"//bar/..."}))
 	})


### PR DESCRIPTION
`//...` specifies any build target within the main repo. Take this into account when determining whether a target is visible to another target when the former uses it as a visibility identifier.

Fixes #138.