### PR TITLE
Correctly compute visibility of target given a child package wildcard

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/please-build/buildtools/build"
@@ -253,7 +252,15 @@ func isSubpackage(basePkg, pkg string) bool {
 	}
 	basePkgParts := strings.Split(basePkg, "/")
 	pkgParts := strings.Split(pkg, "/")
-	return slices.Equal(basePkgParts, pkgParts[:len(basePkgParts)])
+	if len(basePkgParts) > len(pkgParts) {
+		return false
+	}
+	for i := range basePkgParts {
+		if basePkgParts[i] != pkgParts[i] {
+			return false
+		}
+	}
+	return true
 }
 
 type nopCloser struct {

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -219,6 +219,12 @@ func TestCheckVisibility(t *testing.T) {
 			expected:    true,
 		},
 		{
+			description: "Doesn't match child package's wildcard",
+			label:       "//foo/bar:baz",
+			visibility:  []string{"//foo/bar/buh/..."},
+			expected:    false,
+		},
+		{
 			description: "Doesn't match wildcard of a package with different parent",
 			label:       "//foo/bar:baz",
 			visibility:  []string{"//bar/..."},


### PR DESCRIPTION
`isSubpackage` panics when there are more components in the base package name than the target package name. Explicitly compare the package names component-wise to avoid this.