### PR TITLE
fix: adding an external_test when an internal one exists

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -472,7 +472,7 @@ func (u *updater) allocateSources(conf *config.Config, pkgDir string, sources ma
 		if rule == nil {
 			baseName := filepath.Base(pkgDir)
 			name := baseName
-			isExternal_ := importedFile.IsExternal(filepath.Join(u.plzConf.ImportPath(), pkgDir))
+			isExternal := importedFile.IsExternal(filepath.Join(u.plzConf.ImportPath(), pkgDir))
 			kind := "go_library"
 			if importedFile.IsTest() {
 				name += "_test"
@@ -485,7 +485,7 @@ func (u *updater) allocateSources(conf *config.Config, pkgDir string, sources ma
 			_, nameExists := existingRuleNames[name]
 			if nameExists {
 				if importedFile.IsTest() {
-					if isExternal_ {
+					if isExternal {
 						name = fmt.Sprintf("%s_external_test", baseName)
 					} else {
 						name = fmt.Sprintf("%s_internal_test", baseName)
@@ -495,7 +495,7 @@ func (u *updater) allocateSources(conf *config.Config, pkgDir string, sources ma
 				}
 			}
 			rule = edit.NewRule(edit.NewRuleExpr(kind, name), kinds.DefaultKinds[kind], pkgDir)
-			if isExternal_ {
+			if isExternal {
 				setExternal(rule)
 			}
 			newRules = append(newRules, rule)

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -439,6 +439,11 @@ func (u *updater) allocateSources(conf *config.Config, pkgDir string, sources ma
 		return nil, err
 	}
 
+	existingRuleNames := map[string]struct{}{}
+	for _, r := range rules {
+		existingRuleNames[r.Name()] = struct{}{}
+	}
+
 	var newRules []*edit.Rule
 	for _, src := range unallocated {
 		importedFile := sources[src]
@@ -465,7 +470,9 @@ func (u *updater) allocateSources(conf *config.Config, pkgDir string, sources ma
 			}
 		}
 		if rule == nil {
-			name := filepath.Base(pkgDir)
+			baseName := filepath.Base(pkgDir)
+			name := baseName
+			isExternal_ := importedFile.IsExternal(filepath.Join(u.plzConf.ImportPath(), pkgDir))
 			kind := "go_library"
 			if importedFile.IsTest() {
 				name += "_test"
@@ -475,11 +482,24 @@ func (u *updater) allocateSources(conf *config.Config, pkgDir string, sources ma
 				kind = "go_binary"
 				name = "main"
 			}
+			_, nameExists := existingRuleNames[name]
+			if nameExists {
+				if importedFile.IsTest() {
+					if isExternal_ {
+						name = fmt.Sprintf("%s_external_test", baseName)
+					} else {
+						name = fmt.Sprintf("%s_internal_test", baseName)
+					}
+				} else {
+					return nil, fmt.Errorf("rule with name %s already exists in %s", name, pkgDir)
+				}
+			}
 			rule = edit.NewRule(edit.NewRuleExpr(kind, name), kinds.DefaultKinds[kind], pkgDir)
-			if importedFile.IsExternal(filepath.Join(u.plzConf.ImportPath(), pkgDir)) {
+			if isExternal_ {
 				setExternal(rule)
 			}
 			newRules = append(newRules, rule)
+			existingRuleNames[name] = struct{}{}
 		}
 
 		rule.AddSrc(src)

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -51,7 +51,7 @@ func TestAllocateSources(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, newRules, 1)
-	assert.Equal(t, "foo_test", newRules[0].Name())
+	assert.Equal(t, "foo_external_test", newRules[0].Name())
 	assert.ElementsMatch(t, []string{"external_test.go"}, mustGetSources(t, u, newRules[0]))
 
 	assert.ElementsMatch(t, []string{"foo.go", "bar.go"}, mustGetSources(t, u, rules[0]))


### PR DESCRIPTION
And vice versa.

When an existing BUILD file exists with an internal test rule, and a new external test file is added, puku silently ignores the new test file.

Code-wise, `generate.updater.allocateSources` does detect the new file and creates a new external test rule, but gives it the same name as the existing internal test rule, which results in
`generate.updater.updateSources` to ignore the new rule.

This fixes the issue by looking at existing rule names, and adding `external_` to the new test rule name if a rule with the desired name already exists.


---

Sorry, this is a bit out of the blue, let me know if this change is not desired :)
I think this mimicks what wollemi did in this situation.